### PR TITLE
Fix the README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,11 @@ PWMove (Pulse Width Modulation Movement)
 
 Works by translating the analogue values of your gamepad into pulses of various lengths to the corrosponding directions.
 
-How to use:
-
-1. Plug in XBOX or XINPUT device
-
-2. Bind W,A,S,D to whatever digital inputs you would like to emulate analogue movement for, for example UP, DOWN, LEFT, and RIGHT in JNES
-
-3.Start PWMove
-
-4.???
-
-5.Profit
+How to use:  
+1\. Plug in XBOX or XINPUT device  
+2\. Bind W,A,S,D to whatever digital inputs you would like to emulate analogue movement for, for example UP, DOWN, LEFT, and RIGHT in JNES  
+3\. Start PWMove  
+4\. ???  
+5\. Profit  
 
 Made by Elisha Shaddock or eli#8000 on discord


### PR DESCRIPTION
To get Markdown to go to the next line, just put two spaces after the end of the line, no need for a blank line in between.
Also escaped the dots to prevent Markdown from auto formatting the numbered list and indenting it.